### PR TITLE
Removing base url https://api.bitbucket.org/2.0 before call next page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/circleci/find-circle-yml. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/CircleCI-Public/find-circle-yml. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/lib/find_circle_yml/bitbucket/service.rb
+++ b/lib/find_circle_yml/bitbucket/service.rb
@@ -26,6 +26,7 @@ module FindCircleYml
             end
             break unless parsed_response.key?('next')
             url = parsed_response.fetch('next')
+            url['https://api.bitbucket.org/2.0'] = ''
           end
         end
       end


### PR DESCRIPTION
Hello,

I found an error running the code with bitbucket for teams that have many projects. In the cases of bitbucket paging, the url of the next page is coming with the url base "https://api.bitbucket.org/2.0".
This way when he goes to the second page he is putting the url as "https: //api.bitbucket.org/2.0https: //api.bitbucket.org/2.0/repositories/..."
I added a line of code by removing the base url before calling the request method, generating the least possible change.